### PR TITLE
chore(MS-14): 스프링 부트에 Reids 및 MySQL 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'redis.clients:jedis:4.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'redis.clients:jedis:4.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/groot/mindmap/MindmapApplication.java
+++ b/src/main/java/com/groot/mindmap/MindmapApplication.java
@@ -2,7 +2,9 @@ package com.groot.mindmap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class MindmapApplication {
 

--- a/src/main/java/com/groot/mindmap/config/RedisConfiguration.java
+++ b/src/main/java/com/groot/mindmap/config/RedisConfiguration.java
@@ -1,15 +1,13 @@
 package com.groot.mindmap.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
-@EnableCaching
 @Configuration
 public class RedisConfiguration {
 
@@ -29,7 +27,7 @@ public class RedisConfiguration {
         config.setPort(port);
         config.setPassword(password);
 
-        return new JedisConnectionFactory(config);
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/src/main/java/com/groot/mindmap/config/RedisConfiguration.java
+++ b/src/main/java/com/groot/mindmap/config/RedisConfiguration.java
@@ -1,0 +1,41 @@
+package com.groot.mindmap.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@EnableCaching
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Value("${redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setPassword(password);
+
+        return new JedisConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}


### PR DESCRIPTION
## Redis 를 캐시로 사용하고 MySQL을 데이터 저장소로 사용

- 기본적으로 Lettuce 라이브러리가 사용되고 캐싱 전략은 write-through
- 추후에 성능 개선을 위해 write-back을 사용하는 것을 검토

- **테스트 결과**
![image](https://user-images.githubusercontent.com/31034469/230708620-4e38a14b-5dee-4ebc-923c-11331ddaf9c0.png)


