### PR TITLE
feat(MS-26): 노드 CRUD 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	 implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	// implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	// testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	 implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	// implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	// implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/groot/mindmap/MindmapApplication.java
+++ b/src/main/java/com/groot/mindmap/MindmapApplication.java
@@ -3,7 +3,6 @@ package com.groot.mindmap;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-//@EnableCaching
 @SpringBootApplication
 public class MindmapApplication {
 

--- a/src/main/java/com/groot/mindmap/MindmapApplication.java
+++ b/src/main/java/com/groot/mindmap/MindmapApplication.java
@@ -2,9 +2,8 @@ package com.groot.mindmap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 
-@EnableCaching
+//@EnableCaching
 @SpringBootApplication
 public class MindmapApplication {
 

--- a/src/main/java/com/groot/mindmap/exception/ControllerAdvice.java
+++ b/src/main/java/com/groot/mindmap/exception/ControllerAdvice.java
@@ -1,0 +1,40 @@
+package com.groot.mindmap.exception;
+
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "서버에서 예기치 않은 오류가 발생했습니다.";
+    private static final String NEW_LINE_DELIMITER = "\n";
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(final IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handle(final MethodArgumentNotValidException e) {
+        final String errorMessage = e.getBindingResult().getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(NEW_LINE_DELIMITER));
+        return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNoSuchElementException(final NoSuchElementException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException() {
+        return ResponseEntity.internalServerError().body(INTERNAL_SERVER_ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -25,7 +25,7 @@ public class NodeController {
 
     @PostMapping()
     public ResponseEntity<Void> createNode(@Valid @RequestBody final NodeRequest nodeRequest) {
-        final Long id = nodeService.save(nodeRequest);
+        final Long id = nodeService.saveNode(nodeRequest);
         return ResponseEntity.created(URI.create("/api/nodes/" + id)).build();
     }
 
@@ -38,13 +38,13 @@ public class NodeController {
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateNode(@PathVariable Long id, @Valid @RequestBody final NodeRequest nodeRequest) {
-        nodeService.update(id, nodeRequest);
+        nodeService.updateNode(id, nodeRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteNode(@PathVariable Long id) {
-        nodeService.delete(id);
+        nodeService.deleteNode(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,5 +35,11 @@ public class NodeController {
     public ResponseEntity<NodeResponse> findNode(@PathVariable Long id) {
         final NodeResponse nodeResponse = nodeService.findNode(id);
         return ResponseEntity.ok(nodeResponse);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateNode(@PathVariable Long id, @RequestBody final NodeRequest nodeRequest) {
+        nodeService.update(id, nodeRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -1,0 +1,27 @@
+package com.groot.mindmap.node.controller;
+
+import com.groot.mindmap.node.dto.NodeRequest;
+import com.groot.mindmap.node.service.NodeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/node")
+public class NodeController {
+
+    private final NodeService nodeService;
+
+    public NodeController(final NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(@RequestBody final NodeRequest nodeRequest) {
+        nodeService.save(nodeRequest);
+    }
+}

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -5,6 +5,7 @@ import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.service.NodeService;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,5 +42,11 @@ public class NodeController {
     public ResponseEntity<Void> updateNode(@PathVariable Long id, @RequestBody final NodeRequest nodeRequest) {
         nodeService.update(id, nodeRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNode(@PathVariable Long id) {
+        nodeService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -5,6 +5,7 @@ import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.service.NodeService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,14 +17,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/nodes")
 public class NodeController {
 
     private final NodeService nodeService;
-
-    public NodeController(final NodeService nodeService) {
-        this.nodeService = nodeService;
-    }
 
     @PostMapping()
     public ResponseEntity<Void> createNode(@Valid @RequestBody final NodeRequest nodeRequest) {

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -3,6 +3,7 @@ package com.groot.mindmap.node.controller;
 import com.groot.mindmap.node.dto.NodeRequest;
 import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.service.NodeService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,9 +25,8 @@ public class NodeController {
         this.nodeService = nodeService;
     }
 
-    // TODO: @Valid 검증
     @PostMapping()
-    public ResponseEntity<Void> createNode(@RequestBody final NodeRequest nodeRequest) {
+    public ResponseEntity<Void> createNode(@Valid @RequestBody final NodeRequest nodeRequest) {
         final Long id = nodeService.save(nodeRequest);
         return ResponseEntity.created(URI.create("/api/nodes/" + id)).build();
     }
@@ -39,7 +39,7 @@ public class NodeController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateNode(@PathVariable Long id, @RequestBody final NodeRequest nodeRequest) {
+    public ResponseEntity<Void> updateNode(@PathVariable Long id, @Valid @RequestBody final NodeRequest nodeRequest) {
         nodeService.update(id, nodeRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -1,9 +1,12 @@
 package com.groot.mindmap.node.controller;
 
 import com.groot.mindmap.node.dto.NodeRequest;
+import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.service.NodeService;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,9 +22,17 @@ public class NodeController {
         this.nodeService = nodeService;
     }
 
+    // TODO: @Valid 검증
     @PostMapping()
     public ResponseEntity<Void> createNode(@RequestBody final NodeRequest nodeRequest) {
         final Long id = nodeService.save(nodeRequest);
         return ResponseEntity.created(URI.create("/api/nodes/" + id)).build();
+    }
+
+    // TODO: findNodesByPage 구현
+    @GetMapping("/{id}")
+    public ResponseEntity<NodeResponse> findNode(@PathVariable Long id) {
+        final NodeResponse nodeResponse = nodeService.findNode(id);
+        return ResponseEntity.ok(nodeResponse);
     }
 }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -2,15 +2,15 @@ package com.groot.mindmap.node.controller;
 
 import com.groot.mindmap.node.dto.NodeRequest;
 import com.groot.mindmap.node.service.NodeService;
-import org.springframework.http.HttpStatus;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/node")
+@RequestMapping("/api/nodes")
 public class NodeController {
 
     private final NodeService nodeService;
@@ -20,8 +20,8 @@ public class NodeController {
     }
 
     @PostMapping()
-    @ResponseStatus(HttpStatus.CREATED)
-    public void create(@RequestBody final NodeRequest nodeRequest) {
-        nodeService.save(nodeRequest);
+    public ResponseEntity<Void> createNode(@RequestBody final NodeRequest nodeRequest) {
+        final Long id = nodeService.save(nodeRequest);
+        return ResponseEntity.created(URI.create("/api/nodes/" + id)).build();
     }
 }

--- a/src/main/java/com/groot/mindmap/node/domain/Node.java
+++ b/src/main/java/com/groot/mindmap/node/domain/Node.java
@@ -1,0 +1,32 @@
+package com.groot.mindmap.node.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Builder
+public class Node {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String content;
+    private String color;
+    private Long parentId;
+
+    public Node(final Long id, final String title, final String content, final String color, final Long parentId) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.color = color;
+        this.parentId = parentId;
+    }
+}

--- a/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
+++ b/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
@@ -1,0 +1,4 @@
+package com.groot.mindmap.node.dto;
+
+public record NodeRequest(String title, String content, String color, Long parentId) {
+}

--- a/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
+++ b/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
@@ -1,4 +1,17 @@
 package com.groot.mindmap.node.dto;
 
-public record NodeRequest(String title, String content, String color, Long parentId) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NodeRequest(
+        @NotBlank(message = "제목을 입력해주세요.")
+        @Size(max = 30, message = "제목은 30 글자를 넘을 수 없습니다.")
+        String title,
+        @Size(max = 255, message = "content는 255 글자를 넘을 수 없습니다.")
+        String content,
+        @NotBlank(message = "color를 입력해주세요.")
+        String color,
+        @NotNull(message = "부모 node를 선택해주세요.")
+        Long parentId) {
 }

--- a/src/main/java/com/groot/mindmap/node/dto/NodeResponse.java
+++ b/src/main/java/com/groot/mindmap/node/dto/NodeResponse.java
@@ -1,0 +1,4 @@
+package com.groot.mindmap.node.dto;
+
+public record NodeResponse(Long id, String title, String content, String color, Long parentId) {
+}

--- a/src/main/java/com/groot/mindmap/node/repository/NodeRepository.java
+++ b/src/main/java/com/groot/mindmap/node/repository/NodeRepository.java
@@ -1,0 +1,7 @@
+package com.groot.mindmap.node.repository;
+
+import com.groot.mindmap.node.domain.Node;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NodeRepository extends JpaRepository<Node, Long> {
+}

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -1,0 +1,28 @@
+package com.groot.mindmap.node.service;
+
+import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.node.dto.NodeRequest;
+import com.groot.mindmap.node.repository.NodeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class NodeService {
+
+    private final NodeRepository nodeRepository;
+
+    public NodeService(final NodeRepository nodeRepository) {
+        this.nodeRepository = nodeRepository;
+    }
+
+    @Transactional
+    public void save(final NodeRequest nodeRequest) {
+        final Node node = Node.builder()
+                .title(nodeRequest.title())
+                .content(nodeRequest.content())
+                .color(nodeRequest.color())
+                .parentId(nodeRequest.parentId())
+                .build();
+        nodeRepository.save(node);
+    }
+}

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -29,7 +29,24 @@ public class NodeService {
     }
 
     public NodeResponse findNode(final Long id) {
-        final Node node = nodeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 Node가 없습니다."));
+        final Node node = findNodeObject(id);
         return new NodeResponse(node.getId(), node.getTitle(), node.getContent(), node.getColor(), node.getParentId());
+    }
+
+    @Transactional
+    public void update(final Long id, final NodeRequest nodeRequest) {
+        findNodeObject(id);
+        final Node node = Node.builder()
+                .id(id)
+                .title(nodeRequest.title())
+                .content(nodeRequest.content())
+                .color(nodeRequest.color())
+                .parentId(nodeRequest.parentId())
+                .build();
+        nodeRepository.save(node);
+    }
+
+    private Node findNodeObject(final Long id) {
+        return nodeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 Node가 없습니다."));
     }
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -49,4 +49,9 @@ public class NodeService {
     private Node findNodeObject(final Long id) {
         return nodeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 Node가 없습니다."));
     }
+
+    public void delete(final Long id) {
+        findNodeObject(id);
+        nodeRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -16,13 +16,13 @@ public class NodeService {
     }
 
     @Transactional
-    public void save(final NodeRequest nodeRequest) {
+    public Long save(final NodeRequest nodeRequest) {
         final Node node = Node.builder()
                 .title(nodeRequest.title())
                 .content(nodeRequest.content())
                 .color(nodeRequest.color())
                 .parentId(nodeRequest.parentId())
                 .build();
-        nodeRepository.save(node);
+        return nodeRepository.save(node).getId();
     }
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -2,7 +2,9 @@ package com.groot.mindmap.node.service;
 
 import com.groot.mindmap.node.domain.Node;
 import com.groot.mindmap.node.dto.NodeRequest;
+import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.repository.NodeRepository;
+import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,5 +26,10 @@ public class NodeService {
                 .parentId(nodeRequest.parentId())
                 .build();
         return nodeRepository.save(node).getId();
+    }
+
+    public NodeResponse findNode(final Long id) {
+        final Node node = nodeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 Node가 없습니다."));
+        return new NodeResponse(node.getId(), node.getTitle(), node.getContent(), node.getColor(), node.getParentId());
     }
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -18,7 +18,7 @@ public class NodeService {
     }
 
     @Transactional
-    public Long save(final NodeRequest nodeRequest) {
+    public Long saveNode(final NodeRequest nodeRequest) {
         final Node node = Node.builder()
                 .title(nodeRequest.title())
                 .content(nodeRequest.content())
@@ -28,13 +28,14 @@ public class NodeService {
         return nodeRepository.save(node).getId();
     }
 
+    @Transactional(readOnly = true)
     public NodeResponse findNode(final Long id) {
         final Node node = findNodeObject(id);
         return new NodeResponse(node.getId(), node.getTitle(), node.getContent(), node.getColor(), node.getParentId());
     }
 
     @Transactional
-    public void update(final Long id, final NodeRequest nodeRequest) {
+    public void updateNode(final Long id, final NodeRequest nodeRequest) {
         findNodeObject(id);
         final Node node = Node.builder()
                 .id(id)
@@ -50,7 +51,8 @@ public class NodeService {
         return nodeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("해당하는 Node가 없습니다."));
     }
 
-    public void delete(final Long id) {
+    @Transactional
+    public void deleteNode(final Long id) {
         findNodeObject(id);
         nodeRepository.deleteById(id);
     }


### PR DESCRIPTION
## Node REST API

Method | Path
-- | --
GET | /api/nodes/:id
POST | /api/nodes
PUT | /api/nodes/:id
DELETE | /api/nodes/:id

> GET의 경우 id로 해당 노드 하나 조회하는 경우만 구현
> 전체 노드 GET 하는 API는 `Page`를 구현한 후, 구현할 예정

## 도메인 특이사항

- `Page`를 구현하기 전이어서 당장 필요한 필드만 가지고 있음 (-> 추후 추가 예정)
- DTO에서만 검증하고, domain에서 검증은 하지 않고 있음

## DTO 특이사항

- **Record** 타입 사용
- `@Valid` 를 통한 검증
```java
@NotBlank(message = "제목을 입력해주세요.")
@Size(max = 30, message = "제목은 30 글자를 넘을 수 없습니다.")
String title,

@Size(max = 255, message = "content는 255 글자를 넘을 수 없습니다.")
String content,

@NotBlank(message = "color를 입력해주세요.")
String color,

@NotNull(message = "부모 node를 선택해주세요.")
Long parentId
```

## 예외 처리

`ControllerAdvice`에서 `@ExceptionHandler`를 통해 예외 처리

- `IllegalArgumentException` or `MethodArgumentNotValidException` -> **_400 Bad Request_**
- `NoSuchElementException` -> **_404 Not Found_**
- 이 외의 `Exception` -> **_500 Internal Server Error_**

