### PR TITLE
fix(MS-27): 리뷰 피드백 반영 및 메세지 전송 오류 수정

### DIFF
--- a/src/main/java/com/groot/mindmap/message/controller/MessageController.java
+++ b/src/main/java/com/groot/mindmap/message/controller/MessageController.java
@@ -13,12 +13,12 @@ public class MessageController {
     private final MessageService messageService;
     private final RedisService redisService;
 
-    @MessageMapping("/page/add")
+    @MessageMapping("/node/add")
     public void nodeAdd(String message) {
         redisService.sendMessage(messageService.create(message));
     }
 
-    @MessageMapping("/page/delete")
+    @MessageMapping("/node/delete")
     public void nodeDelete(String message) {
         redisService.sendMessage(messageService.delete(message));
     }

--- a/src/main/java/com/groot/mindmap/message/domain/AddMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/AddMessage.java
@@ -1,10 +1,16 @@
 package com.groot.mindmap.message.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class AddMessage extends Message{
 
+    @JsonProperty("parentId")
     private final Long parentId;
 
-    public AddMessage(Long pageId, Long parentId) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public AddMessage(@JsonProperty("pageId") Long pageId,
+                      @JsonProperty("parentId") Long parentId) {
         super(pageId, "ADD");
         this.parentId = parentId;
     }

--- a/src/main/java/com/groot/mindmap/message/domain/AddMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/AddMessage.java
@@ -4,7 +4,7 @@ public class AddMessage extends Message{
 
     private final Long parentId;
 
-    public AddMessage(String pageId, Long parentId) {
+    public AddMessage(Long pageId, Long parentId) {
         super(pageId, "ADD");
         this.parentId = parentId;
     }

--- a/src/main/java/com/groot/mindmap/message/domain/DeleteMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/DeleteMessage.java
@@ -1,11 +1,17 @@
 package com.groot.mindmap.message.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class DeleteMessage extends Message{
 
+    @JsonProperty("nodeId")
     private final Long nodeId;
 
-    public DeleteMessage(Long pageId, String type, Long nodeId) {
-        super(pageId, type);
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public DeleteMessage(@JsonProperty("pageId") Long pageId,
+                         @JsonProperty("nodeId") Long nodeId) {
+        super(pageId, "DELETE");
         this.nodeId = nodeId;
     }
 

--- a/src/main/java/com/groot/mindmap/message/domain/DeleteMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/DeleteMessage.java
@@ -4,7 +4,7 @@ public class DeleteMessage extends Message{
 
     private final Long nodeId;
 
-    public DeleteMessage(String pageId, String type, Long nodeId) {
+    public DeleteMessage(Long pageId, String type, Long nodeId) {
         super(pageId, type);
         this.nodeId = nodeId;
     }

--- a/src/main/java/com/groot/mindmap/message/domain/Message.java
+++ b/src/main/java/com/groot/mindmap/message/domain/Message.java
@@ -1,13 +1,22 @@
 package com.groot.mindmap.message.domain;
 
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
-@RequiredArgsConstructor
+@Getter
 public abstract class Message {
+
+    @JsonProperty("pageId")
     private final Long pageId;
+
+    @JsonProperty("type")
     private final String type;
 
-    public Long pageId() {
-        return pageId;
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public Message(@JsonProperty("pageId") Long pageId,
+                   @JsonProperty("type") String type) {
+        this.pageId = pageId;
+        this.type = type;
     }
 }

--- a/src/main/java/com/groot/mindmap/message/domain/Message.java
+++ b/src/main/java/com/groot/mindmap/message/domain/Message.java
@@ -4,10 +4,10 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public abstract class Message {
-    private final String pageId;
+    private final Long pageId;
     private final String type;
 
-    public String pageId() {
+    public Long pageId() {
         return pageId;
     }
 }

--- a/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
@@ -8,12 +8,12 @@ public class NodeListMessage extends Message {
 
     private final List<Node> nodes;
 
-    private NodeListMessage(String pageId, String type, List<Node> nodes) {
+    private NodeListMessage(Long pageId, String type, List<Node> nodes) {
         super(pageId, type);
         this.nodes = nodes;
     }
 
-    public static NodeListMessage create(String pageId, String type, List<Node> nodes) {
+    public static NodeListMessage create(Long pageId, String type, List<Node> nodes) {
         // TODO validate 로직 추가
         return new NodeListMessage(pageId, type, nodes);
     }

--- a/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
@@ -1,9 +1,11 @@
 package com.groot.mindmap.message.domain;
 
 import com.groot.mindmap.node.domain.Node;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 public class NodeListMessage extends Message {
 
     private final List<Node> nodes;
@@ -13,8 +15,8 @@ public class NodeListMessage extends Message {
         this.nodes = nodes;
     }
 
-    public static NodeListMessage create(Long pageId, String type, List<Node> nodes) {
+    public static NodeListMessage create(Message message, List<Node> nodes) {
         // TODO validate 로직 추가
-        return new NodeListMessage(pageId, type, nodes);
+        return new NodeListMessage(message.getPageId(), message.getType(), nodes);
     }
 }

--- a/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
@@ -10,13 +10,8 @@ public class NodeListMessage extends Message {
 
     private final List<Node> nodes;
 
-    private NodeListMessage(Long pageId, String type, List<Node> nodes) {
-        super(pageId, type);
+    public NodeListMessage(Message message, List<Node> nodes) {
+        super(message.getPageId(), message.getType());
         this.nodes = nodes;
-    }
-
-    public static NodeListMessage create(Message message, List<Node> nodes) {
-        // TODO validate 로직 추가
-        return new NodeListMessage(message.getPageId(), message.getType(), nodes);
     }
 }

--- a/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
@@ -1,7 +1,10 @@
 package com.groot.mindmap.message.domain;
 
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
 public class UserListMessage extends Message{
 
     private final List<String> users;

--- a/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
@@ -9,13 +9,8 @@ public class UserListMessage extends Message{
 
     private final List<String> users;
 
-    private UserListMessage(Long pageId, String type, List<String> users) {
+    public UserListMessage(Long pageId, String type, List<String> users) {
         super(pageId, type);
         this.users = users;
-    }
-
-    public static UserListMessage create(Long pageId, String type, List<String> users) {
-        // TODO validate 로직 추가
-        return new UserListMessage(pageId, type, users);
     }
 }

--- a/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/UserListMessage.java
@@ -6,12 +6,12 @@ public class UserListMessage extends Message{
 
     private final List<String> users;
 
-    private UserListMessage(String pageId, String type, List<String> users) {
+    private UserListMessage(Long pageId, String type, List<String> users) {
         super(pageId, type);
         this.users = users;
     }
 
-    public static UserListMessage create(String pageId, String type, List<String> users) {
+    public static UserListMessage create(Long pageId, String type, List<String> users) {
         // TODO validate 로직 추가
         return new UserListMessage(pageId, type, users);
     }

--- a/src/main/java/com/groot/mindmap/message/repository/RedisRepository.java
+++ b/src/main/java/com/groot/mindmap/message/repository/RedisRepository.java
@@ -14,7 +14,7 @@ public class RedisRepository {
     private static final String ENTER_INFO = "ENTER_INFO";
 
     @Resource(name = "redisTemplate")
-    private HashOperations<String, String, String> enterInfos;
+    private HashOperations<String, String, Long> enterInfos;
 
     @Resource(name = "redisTemplate")
     private ListOperations<String, String> userLists;
@@ -24,7 +24,7 @@ public class RedisRepository {
      * @param sessionId 유저의 세션 ID
      * @param pageId 페이지의 ID
      */
-    public void setEnterInfo(String sessionId, String pageId) {
+    public void setEnterInfo(String sessionId, Long pageId) {
         enterInfos.put(ENTER_INFO, sessionId, pageId);
     }
 
@@ -41,7 +41,7 @@ public class RedisRepository {
      * @param sessionId 유저의 세션 ID
      * @return Page ID
      */
-    public String getEnteredPageId(String sessionId) {
+    public Long getEnteredPageId(String sessionId) {
         return enterInfos.get(ENTER_INFO, sessionId);
     }
 
@@ -50,7 +50,7 @@ public class RedisRepository {
      * @param pageId Page ID
      * @param name 유저의 이름(또는 ID)
      */
-    public void addUser(String pageId, String name) {
+    public void addUser(Long pageId, String name) {
         userLists.leftPush(USER_LIST + "_" + pageId, name);
     }
 
@@ -59,11 +59,11 @@ public class RedisRepository {
      * @param pageId Page ID
      * @return names 유저들의 이름 리스트(또는 유저 ID 리스트)
      */
-    public List<String> getUsers(String pageId) {
+    public List<String> getUsers(Long pageId) {
         return userLists.range(USER_LIST + "_" + pageId, 0, -1);
     }
 
-    public void removeUser(String pageId, String name) {
+    public void removeUser(Long pageId, String name) {
         userLists.remove(USER_LIST + "_" + pageId, 1, name);
     }
 }

--- a/src/main/java/com/groot/mindmap/message/repository/RedisRepository.java
+++ b/src/main/java/com/groot/mindmap/message/repository/RedisRepository.java
@@ -3,11 +3,11 @@ package com.groot.mindmap.message.repository;
 import jakarta.annotation.Resource;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.ListOperations;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Service
+@Repository
 public class RedisRepository {
 
     private static final String USER_LIST = "USER_LIST";

--- a/src/main/java/com/groot/mindmap/message/service/MessageService.java
+++ b/src/main/java/com/groot/mindmap/message/service/MessageService.java
@@ -26,7 +26,7 @@ public class MessageService {
             AddMessage addMessage = mapper.readValue(message, AddMessage.class);
             NodeRequest request = new NodeRequest("제목 없음", "내용 없음", "black", addMessage.parentId());
             nodeService.create(request);
-            return NodeListMessage.create(addMessage, nodeService.list());
+            return new NodeListMessage(addMessage, nodeService.list());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -37,7 +37,7 @@ public class MessageService {
         try {
             DeleteMessage deleteMessage = mapper.readValue(message, DeleteMessage.class);
             nodeService.delete(deleteMessage.nodeId());
-            return NodeListMessage.create(deleteMessage, nodeService.list());
+            return new NodeListMessage(deleteMessage, nodeService.list());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/groot/mindmap/message/service/MessageService.java
+++ b/src/main/java/com/groot/mindmap/message/service/MessageService.java
@@ -26,7 +26,7 @@ public class MessageService {
             AddMessage addMessage = mapper.readValue(message, AddMessage.class);
             NodeRequest request = new NodeRequest("제목 없음", "내용 없음", "black", addMessage.parentId());
             nodeService.create(request);
-            return NodeListMessage.create(addMessage.pageId(), "ADD", nodeService.list());
+            return NodeListMessage.create(addMessage, nodeService.list());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -37,7 +37,7 @@ public class MessageService {
         try {
             DeleteMessage deleteMessage = mapper.readValue(message, DeleteMessage.class);
             nodeService.delete(deleteMessage.nodeId());
-            return NodeListMessage.create(deleteMessage.pageId(), "DELETE", nodeService.list());
+            return NodeListMessage.create(deleteMessage, nodeService.list());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/groot/mindmap/util/MessagePublisher.java
+++ b/src/main/java/com/groot/mindmap/util/MessagePublisher.java
@@ -1,10 +1,10 @@
 package com.groot.mindmap.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.groot.mindmap.message.domain.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.json.JSONParser;
+import org.apache.tomcat.util.json.ParseException;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
@@ -26,8 +26,9 @@ public class MessagePublisher {
 
     private Long getPageId(String message) {
         try {
-            return mapper.readValue(message, Message.class).pageId();
-        } catch (JsonProcessingException e) {
+            JSONParser parser = new JSONParser(message);
+            return Long.valueOf(parser.object().get("pageId").toString());
+        } catch (ParseException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/groot/mindmap/util/MessagePublisher.java
+++ b/src/main/java/com/groot/mindmap/util/MessagePublisher.java
@@ -24,7 +24,7 @@ public class MessagePublisher {
         operations.convertAndSend("/sub/page/" + getPageId(message), message);
     }
 
-    private String getPageId(String message) {
+    private Long getPageId(String message) {
         try {
             return mapper.readValue(message, Message.class).pageId();
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/groot/mindmap/util/StompHandler.java
+++ b/src/main/java/com/groot/mindmap/util/StompHandler.java
@@ -34,7 +34,7 @@ public class StompHandler implements ChannelInterceptor {
             case SUBSCRIBE -> {
                 String sessionId = Objects.requireNonNull(message.getHeaders().get("simpSessionId")).toString();
                 String destination = Objects.requireNonNull(message.getHeaders().get("simpDestination")).toString();
-                String pageId = getPageId(destination);
+                Long pageId = getPageId(destination);
 
                 // 유저의 접속 정보를 저장하고 현재 접속 중인 유저 리스트에 새로운 유저를 추가
                 repository.setEnterInfo(sessionId, pageId);
@@ -46,7 +46,7 @@ public class StompHandler implements ChannelInterceptor {
             }
             case DISCONNECT -> {
                 String sessionId = Objects.requireNonNull(message.getHeaders().get("simpSessionId")).toString();
-                String pageId = repository.getEnteredPageId(sessionId);
+                Long pageId = repository.getEnteredPageId(sessionId);
                 String name = Optional.ofNullable((Principal) message.getHeaders().get("simpUser"))
                         .map(Principal::getName)
                         .orElseThrow();
@@ -68,8 +68,8 @@ public class StompHandler implements ChannelInterceptor {
      * @param destination 헤더에 포함된 destination(Page ID를 포함하고 있음)
      * @return Page ID
      */
-    private String getPageId(String destination) {
+    private Long getPageId(String destination) {
         int lastIndex = destination.lastIndexOf("/");
-        return lastIndex == -1 ? "" : destination.substring(lastIndex + 1);
+        return Long.valueOf(lastIndex == -1 ? "" : destination.substring(lastIndex + 1));
     }
 }

--- a/src/main/java/com/groot/mindmap/util/StompHandler.java
+++ b/src/main/java/com/groot/mindmap/util/StompHandler.java
@@ -43,7 +43,7 @@ public class StompHandler implements ChannelInterceptor {
                 // 현재 접속 중인 유저 목록에 대한 메세지를 pub
                 List<String> users = repository.getUsers(pageId);
 
-                service.sendMessage(UserListMessage.create(pageId, "ENTRY", users));
+                service.sendMessage(new UserListMessage(pageId, "ENTRY", users));
             }
             case DISCONNECT -> {
                 String sessionId = Objects.requireNonNull(message.getHeaders().get("simpSessionId")).toString();
@@ -58,7 +58,7 @@ public class StompHandler implements ChannelInterceptor {
 
                 // 현재 접속 중인 유저 목록에 대한 메세지를 pub
                 List<String> users = repository.getUsers(pageId);
-                service.sendMessage(UserListMessage.create(pageId, "EXIT", users));
+                service.sendMessage(new UserListMessage(pageId, "EXIT", users));
             }
         }
         return message;

--- a/src/main/java/com/groot/mindmap/util/StompHandler.java
+++ b/src/main/java/com/groot/mindmap/util/StompHandler.java
@@ -42,6 +42,7 @@ public class StompHandler implements ChannelInterceptor {
 
                 // 현재 접속 중인 유저 목록에 대한 메세지를 pub
                 List<String> users = repository.getUsers(pageId);
+
                 service.sendMessage(UserListMessage.create(pageId, "ENTRY", users));
             }
             case DISCONNECT -> {
@@ -49,7 +50,7 @@ public class StompHandler implements ChannelInterceptor {
                 Long pageId = repository.getEnteredPageId(sessionId);
                 String name = Optional.ofNullable((Principal) message.getHeaders().get("simpUser"))
                         .map(Principal::getName)
-                        .orElseThrow();
+                        .orElse("NO_NAME");
 
                 // 유저의 접속 정보를 삭제하고 현재 접속 중인 유저 리스트에서 유저를 제거
                 repository.removeUser(pageId, name);


### PR DESCRIPTION
## 리뷰 반영
- [X] RedisRepository의 @Service 어노테이션을 @Repository 어노테이션으로 변경
- [X] Message 들의 인스턴스 생성 방식을 팩터리 메서드에서 생성자로 변경

## 오류 수정
- 파싱 오류로 인해 메세지가 클라이언트로 전송되지 않던 오류를 수정

## 리팩터링
- 페이지 ID의 자료형을 String에서 Long으로 변경