### PR TITLE
feat(MS-37): 최초 로그인 시 유저를 생성하는 기능 추가

### DIFF
--- a/src/main/java/com/groot/mindmap/user/domain/User.java
+++ b/src/main/java/com/groot/mindmap/user/domain/User.java
@@ -20,4 +20,5 @@ public class User {
     private String name;
     private String email;
     private String profileImage;
+    private String platform;
 }

--- a/src/main/java/com/groot/mindmap/user/repository/UserRepository.java
+++ b/src/main/java/com/groot/mindmap/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.groot.mindmap.user.repository;
 import com.groot.mindmap.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByPlatformAndEmail(String platform, String email);
 }

--- a/src/main/java/com/groot/mindmap/user/service/UserService.java
+++ b/src/main/java/com/groot/mindmap/user/service/UserService.java
@@ -1,10 +1,13 @@
 package com.groot.mindmap.user.service;
 
+import com.groot.mindmap.user.domain.AuthInformation;
 import com.groot.mindmap.user.domain.User;
 import com.groot.mindmap.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -13,12 +16,18 @@ public class UserService {
     private final UserRepository repository;
 
     @Transactional
-    public Long create(final String name, final String email, final String profileImage) {
+    public Long create(final AuthInformation information) {
         User user = User.builder()
-                .name(name)
-                .email(email)
-                .profileImage(profileImage)
+                .name(information.name())
+                .email(information.email())
+                .profileImage(information.profileImage())
+                .platform(information.platform())
                 .build();
         return repository.save(user).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findByPlatformAndEmail(final String platform, final String email) {
+        return repository.findByPlatformAndEmail(platform, email);
     }
 }


### PR DESCRIPTION
## User 특이사항
- 최초 로그인 시에 각 User를 구분하는데에 사용하기 위한 platform 필드를 추가
```java
public class User {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
    private String name;
    private String email;
    private String profileImage;
    private String platform;
}
```

## 추가된 기능
- 인증 및 유저 정보를 가져오는 것까지 성공했을 때 호출되는 핸들러에서 최초 로그인한 유저일 시 인증 정보를 기반으로 User를 데이터베이스에 저장
    - User가 저장되어있는지 구분하는 것은 platform(소셜 로그인 플랫폼)과 email(개인을 구분가능한 이메일)
```java
    private AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
        return (request, response, authentication) -> {
            OAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();

            // Get the platform name
            String platform = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
            Assert.notNull(platform, "platform can not be null");

            AuthInformation information = AuthInformationFactory.valueOf(platform.toUpperCase()).create(auth2User);

            Optional<User> user = userService.findByPlatformAndEmail(information.platform(), information.email());
            if (user.isEmpty()) {
                userService.create(information);
            }

            // TODO JWT 생성 후 헤더에 넣어 반환하는 로직 추가

            response.sendRedirect("/login?success=true");
        };
    }
```

## 추가 구현해야할 부분
- JWT 인증방식을 도입해 로그인 시 토큰을 생성해 헤더에 추가 및 반환하는 로직을 추가