### PR TITLE
feat(MS-27): Node 반환 자료구조 변경 및 로그인 기능에 대한 추가 구현

### DIFF
--- a/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
@@ -9,17 +9,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.util.Assert;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Optional;
 
@@ -33,6 +33,10 @@ public class Oauth2LoginSecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
+                .headers()
+                    .frameOptions().disable()
+                    .contentTypeOptions().disable()
+                .and()
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/oauth2/authorization")
@@ -43,7 +47,27 @@ public class Oauth2LoginSecurityConfiguration {
                                 .userService(new DefaultOAuth2UserService()))
                         .successHandler(oAuth2AuthenticationSuccessHandler())
                         .failureHandler(oAuth2AuthenticationFailureHandler()))
+                .authorizeHttpRequests()
+                    .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                    .anyRequest().authenticated()
+                .and()
+                .cors()
+                .and()
                 .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOrigin("http://localhost:5173");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
@@ -52,14 +76,7 @@ public class Oauth2LoginSecurityConfiguration {
 
     private AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
         return (request, response, authentication) -> {
-            OAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();
-
-            // Get the platform name
-            String platform = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
-            Assert.notNull(platform, "platform can not be null");
-
-            AuthInformation information = AuthInformationFactory.valueOf(platform.toUpperCase()).create(auth2User);
-
+            AuthInformation information = AuthInformationFactory.of(authentication);
             Optional<User> user = userService.findByPlatformAndEmail(information.platform(), information.email());
             if (user.isEmpty()) {
                 userService.create(information);
@@ -67,7 +84,7 @@ public class Oauth2LoginSecurityConfiguration {
 
             // TODO JWT 생성 후 헤더에 넣어 반환하는 로직 추가
 
-            response.sendRedirect("/login?success=true");
+            response.sendRedirect("http://localhost:5173");
         };
     }
 

--- a/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
-public class Oauth2LoginSecurityConfiguration {
+public class WebSecurityConfiguration {
 
     private final UserService userService;
 
@@ -90,7 +90,7 @@ public class Oauth2LoginSecurityConfiguration {
 
     private AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
         return (request, response, exception) -> {
-            response.sendRedirect("/login?error=true");
+            response.sendRedirect("/login");
         };
     }
 }

--- a/src/main/java/com/groot/mindmap/message/controller/MessageController.java
+++ b/src/main/java/com/groot/mindmap/message/controller/MessageController.java
@@ -7,20 +7,20 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
 
 @RequiredArgsConstructor
+@MessageMapping("/node")
 @Controller
 public class MessageController {
 
     private final MessageService messageService;
     private final RedisService redisService;
 
-    @MessageMapping("/node/add")
+    @MessageMapping("/add")
     public void nodeAdd(String message) {
         redisService.sendMessage(messageService.create(message));
     }
 
-    @MessageMapping("/node/delete")
+    @MessageMapping("/delete")
     public void nodeDelete(String message) {
         redisService.sendMessage(messageService.delete(message));
     }
-
 }

--- a/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
@@ -4,14 +4,17 @@ import com.groot.mindmap.node.domain.Node;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Getter
 public class NodeListMessage extends Message {
 
-    private final List<Node> nodes;
+    private final Map<Long, Node> nodes;
 
     public NodeListMessage(Message message, List<Node> nodes) {
         super(message.getPageId(), message.getType());
-        this.nodes = nodes;
+        this.nodes = nodes.stream().collect(Collectors.toMap(Node::getId, Function.identity()));
     }
 }

--- a/src/main/java/com/groot/mindmap/message/service/MessageService.java
+++ b/src/main/java/com/groot/mindmap/message/service/MessageService.java
@@ -12,6 +12,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+
 @RequiredArgsConstructor
 @Service
 public class MessageService {
@@ -24,7 +26,7 @@ public class MessageService {
         // TODO 임의로 NodeRequest 를 생성하고, Pub 할 메세지를 생성해 반환
         try {
             AddMessage addMessage = mapper.readValue(message, AddMessage.class);
-            NodeRequest request = new NodeRequest("제목 없음", "내용 없음", "black", addMessage.parentId());
+            NodeRequest request = new NodeRequest("제목 없음", "내용 없음", "black", addMessage.parentId(), new ArrayList<>());
             nodeService.create(request);
             return new NodeListMessage(addMessage, nodeService.list());
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/groot/mindmap/node/domain/Node.java
+++ b/src/main/java/com/groot/mindmap/node/domain/Node.java
@@ -1,16 +1,17 @@
 package com.groot.mindmap.node.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class Node {
 
@@ -21,12 +22,6 @@ public class Node {
     private String content;
     private String color;
     private Long parentId;
-
-    public Node(final Long id, final String title, final String content, final String color, final Long parentId) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.color = color;
-        this.parentId = parentId;
-    }
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<Long> children;
 }

--- a/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
+++ b/src/main/java/com/groot/mindmap/node/dto/NodeRequest.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public record NodeRequest(
         @NotBlank(message = "제목을 입력해주세요.")
         @Size(max = 30, message = "제목은 30 글자를 넘을 수 없습니다.")
@@ -13,5 +15,8 @@ public record NodeRequest(
         @NotBlank(message = "color를 입력해주세요.")
         String color,
         @NotNull(message = "부모 node를 선택해주세요.")
-        Long parentId) {
+        Long parentId,
+        @NotNull(message = "자식 node는 null일 수 없습니다.")
+        List<Long> children)
+{
 }

--- a/src/main/java/com/groot/mindmap/node/dto/NodeResponse.java
+++ b/src/main/java/com/groot/mindmap/node/dto/NodeResponse.java
@@ -1,4 +1,6 @@
 package com.groot.mindmap.node.dto;
 
-public record NodeResponse(Long id, String title, String content, String color, Long parentId) {
+import java.util.List;
+
+public record NodeResponse(Long id, String title, String content, String color, Long parentId, List<Long> children) {
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -26,14 +26,20 @@ public class NodeService {
                 .content(nodeRequest.content())
                 .color(nodeRequest.color())
                 .parentId(nodeRequest.parentId())
+                .children(nodeRequest.children())
                 .build();
-        return nodeRepository.save(node).getId();
+
+        Node child = nodeRepository.save(node);
+        // TODO 부모의 자식 노드리스트에 자식 추가
+//        Node parent = findNodeObject(nodeRequest.parentId());
+//        parent.getChildren().add(child.getId());
+        return child.getId();
     }
 
     @Transactional(readOnly = true)
     public NodeResponse detail(final Long id) {
         final Node node = findNodeObject(id);
-        return new NodeResponse(node.getId(), node.getTitle(), node.getContent(), node.getColor(), node.getParentId());
+        return new NodeResponse(node.getId(), node.getTitle(), node.getContent(), node.getColor(), node.getParentId(), node.getChildren());
     }
 
     @Transactional(readOnly = true)
@@ -51,6 +57,7 @@ public class NodeService {
                 .content(nodeRequest.content())
                 .color(nodeRequest.color())
                 .parentId(nodeRequest.parentId())
+                .children(nodeRequest.children())
                 .build();
         nodeRepository.save(node);
     }
@@ -61,6 +68,7 @@ public class NodeService {
 
     @Transactional
     public void delete(final Long id) {
+        // TODO 부모노드를 삭제할 때 자식 노드들도 한꺼번에 삭제하는 로직 추가
         findNodeObject(id);
         nodeRepository.deleteById(id);
     }

--- a/src/main/java/com/groot/mindmap/user/domain/AuthInformationFactory.java
+++ b/src/main/java/com/groot/mindmap/user/domain/AuthInformationFactory.java
@@ -1,5 +1,8 @@
 package com.groot.mindmap.user.domain;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.util.Assert;
 
@@ -48,4 +51,14 @@ public enum AuthInformationFactory {
     };
 
     public abstract AuthInformation create(OAuth2User auth2User);
+
+    public static AuthInformation of(Authentication authentication) {
+        OAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();
+
+        // Get the platform name
+        String platform = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+        Assert.notNull(platform, "platform can not be null");
+
+        return AuthInformationFactory.valueOf(platform.toUpperCase()).create(auth2User);
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
- 소셜 로그인 이후 현재 접속중인 유저 리스트를 실제 유저를 사용하도록 변경
- Node Entity 필드에 자식 노드 ID 리스트를 추가(List<Long>) -> 추후에 List<Node>로 변경하는 것을 검토
- NodeListMessage의 Node들을 List가 아닌 Map으로 반환하도록 변경

## 추가 구현해야 할 부분
- 노드를 추가할 때 부모 노드의 자식 노드 ID 리스트에 새로 추가된 노드 ID를 넣기
- 노드를 삭제할 때 해당 노드의 자식 노드들까지 한꺼번에 삭제하도록 변경