### PR TITLE
refactor(MS-27): Allowed Origin 주소를 환경 변수로 사용하도록 변경

### DIFF
--- a/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/groot/mindmap/config/WebSecurityConfiguration.java
@@ -37,6 +37,9 @@ public class WebSecurityConfiguration {
     @Value("${login.failure.redirect-uri}")
     private String failureUrl;
 
+    @Value("${allowed.origin.url}")
+    private String allowedOrigin;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
@@ -67,7 +70,7 @@ public class WebSecurityConfiguration {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("http://localhost:5173");
+        configuration.addAllowedOrigin(allowedOrigin);
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## 주요 변경 사항
- Allowed Origin 주소를 환경 변수로 사용하도록 변경
- 현재는 기본 클라이언트 주소를 사용