### PR TITLE
feat(MS-42): Page 도메인 추가 및 Node와의 연관 기능 구현

### DIFF
--- a/src/main/java/com/groot/mindmap/MindmapApplication.java
+++ b/src/main/java/com/groot/mindmap/MindmapApplication.java
@@ -2,8 +2,10 @@ package com.groot.mindmap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MindmapApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/groot/mindmap/exception/ControllerAdvice.java
+++ b/src/main/java/com/groot/mindmap/exception/ControllerAdvice.java
@@ -1,13 +1,14 @@
 package com.groot.mindmap.exception;
 
-import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class ControllerAdvice {

--- a/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
+++ b/src/main/java/com/groot/mindmap/message/domain/NodeListMessage.java
@@ -1,6 +1,6 @@
 package com.groot.mindmap.message.domain;
 
-import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.node.dto.NodeResponse;
 import lombok.Getter;
 
 import java.util.List;
@@ -11,10 +11,10 @@ import java.util.stream.Collectors;
 @Getter
 public class NodeListMessage extends Message {
 
-    private final Map<Long, Node> nodes;
+    private final Map<Long, NodeResponse> nodes;
 
-    public NodeListMessage(Message message, List<Node> nodes) {
+    public NodeListMessage(Message message, List<NodeResponse> nodes) {
         super(message.getPageId(), message.getType());
-        this.nodes = nodes.stream().collect(Collectors.toMap(Node::getId, Function.identity()));
+        this.nodes = nodes.stream().collect(Collectors.toMap(NodeResponse::id, Function.identity()));
     }
 }

--- a/src/main/java/com/groot/mindmap/message/service/MessageService.java
+++ b/src/main/java/com/groot/mindmap/message/service/MessageService.java
@@ -27,8 +27,8 @@ public class MessageService {
         try {
             AddMessage addMessage = mapper.readValue(message, AddMessage.class);
             NodeRequest request = new NodeRequest("제목 없음", "내용 없음", "black", addMessage.parentId(), new ArrayList<>());
-            nodeService.create(request);
-            return new NodeListMessage(addMessage, nodeService.list());
+            nodeService.create(request, addMessage.getPageId());
+            return new NodeListMessage(addMessage, nodeService.list(addMessage.getPageId()));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -39,7 +39,7 @@ public class MessageService {
         try {
             DeleteMessage deleteMessage = mapper.readValue(message, DeleteMessage.class);
             nodeService.delete(deleteMessage.nodeId());
-            return new NodeListMessage(deleteMessage, nodeService.list());
+            return new NodeListMessage(deleteMessage, nodeService.list(deleteMessage.getPageId()));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/groot/mindmap/node/controller/NodeController.java
+++ b/src/main/java/com/groot/mindmap/node/controller/NodeController.java
@@ -4,17 +4,11 @@ import com.groot.mindmap.node.dto.NodeRequest;
 import com.groot.mindmap.node.dto.NodeResponse;
 import com.groot.mindmap.node.service.NodeService;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,17 +17,15 @@ public class NodeController {
 
     private final NodeService nodeService;
 
-    @PostMapping()
-    public ResponseEntity<Void> createNode(@Valid @RequestBody final NodeRequest nodeRequest) {
-        final Long id = nodeService.create(nodeRequest);
-        return ResponseEntity.created(URI.create("/api/nodes/" + id)).build();
-    }
-
-    // TODO: findNodesByPage 구현
     @GetMapping("/{id}")
     public ResponseEntity<NodeResponse> findNode(@PathVariable Long id) {
         final NodeResponse nodeResponse = nodeService.detail(id);
         return ResponseEntity.ok(nodeResponse);
+    }
+
+    @GetMapping("/list/{pageId}")
+    public ResponseEntity<List<NodeResponse>> findNodes(@PathVariable Long pageId) {
+        return ResponseEntity.ok(nodeService.list(pageId));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/groot/mindmap/node/domain/Node.java
+++ b/src/main/java/com/groot/mindmap/node/domain/Node.java
@@ -1,5 +1,7 @@
 package com.groot.mindmap.node.domain;
 
+import com.groot.mindmap.page.domain.Page;
+import com.groot.mindmap.util.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,15 +15,35 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Node {
+public class Node extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
+    @Builder.Default
+    private String title = "제목 없음";
     private String content;
     private String color;
     private Long parentId;
     @ElementCollection(fetch = FetchType.EAGER)
     private List<Long> children;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Page page;
+
+    public static Node defaultNode() {
+        return Node.builder()
+                .content("")
+                .color("#ffffff")
+                .parentId(null)
+                .children(List.of())
+                .build();
+    }
+
+    public void setPage(Page page) {
+        this.page = page;
+        if (!page.getNodes().contains(this)) {
+            page.getNodes().add(this);
+        }
+    }
 }

--- a/src/main/java/com/groot/mindmap/node/repository/NodeRepository.java
+++ b/src/main/java/com/groot/mindmap/node/repository/NodeRepository.java
@@ -1,7 +1,12 @@
 package com.groot.mindmap.node.repository;
 
 import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.page.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NodeRepository extends JpaRepository<Node, Long> {
+
+    List<Node> findByPage(Page page);
 }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -72,6 +72,11 @@ public class NodeService {
     @Transactional
     public void delete(final Long id) {
         Node parent = findNodeObject(id);
+
+        if (parent.getParentId() == null) {
+            throw new IllegalArgumentException("루트 노드는 삭제할 수 없습니다.");
+        }
+
         for (Long childId : parent.getChildren()) {
             delete(childId);
         }

--- a/src/main/java/com/groot/mindmap/node/service/NodeService.java
+++ b/src/main/java/com/groot/mindmap/node/service/NodeService.java
@@ -71,9 +71,11 @@ public class NodeService {
 
     @Transactional
     public void delete(final Long id) {
-        // TODO 부모노드를 삭제할 때 자식 노드들도 한꺼번에 삭제하는 로직 추가
-        findNodeObject(id);
-        repository.deleteById(id);
+        Node parent = findNodeObject(id);
+        for (Long childId : parent.getChildren()) {
+            delete(childId);
+        }
+        repository.delete(parent);
     }
 
     private NodeResponse mapToDto(Node node) {

--- a/src/main/java/com/groot/mindmap/page/controller/PageController.java
+++ b/src/main/java/com/groot/mindmap/page/controller/PageController.java
@@ -1,0 +1,24 @@
+package com.groot.mindmap.page.controller;
+
+import com.groot.mindmap.page.service.PageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/pages")
+@RestController
+public class PageController {
+
+    private final PageService service;
+
+    @PostMapping
+    public ResponseEntity<Void> pageAdd() {
+        final Long id = service.create();
+        return ResponseEntity.created(URI.create("/api/pages/" + id)).build();
+    }
+}

--- a/src/main/java/com/groot/mindmap/page/controller/PageController.java
+++ b/src/main/java/com/groot/mindmap/page/controller/PageController.java
@@ -3,7 +3,7 @@ package com.groot.mindmap.page.controller;
 import com.groot.mindmap.page.service.PageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +16,7 @@ public class PageController {
 
     private final PageService service;
 
-    @PostMapping
+    @GetMapping
     public ResponseEntity<Void> pageAdd() {
         final Long id = service.create();
         return ResponseEntity.created(URI.create("/api/pages/" + id)).build();

--- a/src/main/java/com/groot/mindmap/page/controller/PageController.java
+++ b/src/main/java/com/groot/mindmap/page/controller/PageController.java
@@ -3,7 +3,7 @@ package com.groot.mindmap.page.controller;
 import com.groot.mindmap.page.service.PageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +16,7 @@ public class PageController {
 
     private final PageService service;
 
-    @GetMapping
+    @PostMapping
     public ResponseEntity<Void> pageAdd() {
         final Long id = service.create();
         return ResponseEntity.created(URI.create("/api/pages/" + id)).build();

--- a/src/main/java/com/groot/mindmap/page/domain/Page.java
+++ b/src/main/java/com/groot/mindmap/page/domain/Page.java
@@ -1,0 +1,41 @@
+package com.groot.mindmap.page.domain;
+
+import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.util.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Page extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Builder.Default
+    private String title = "제목 없음";
+
+    @Builder.Default
+    @OneToMany(mappedBy = "page",
+            cascade = {CascadeType.ALL},
+            fetch = FetchType.LAZY,
+            orphanRemoval = true)
+    private List<Node> nodes = new ArrayList<>();
+
+    public void addNode(Node node) {
+        this.nodes.add(node);
+        if (node.getPage() != this) {
+            node.setPage(this);
+        }
+    }
+}

--- a/src/main/java/com/groot/mindmap/page/repository/PageRepository.java
+++ b/src/main/java/com/groot/mindmap/page/repository/PageRepository.java
@@ -1,0 +1,7 @@
+package com.groot.mindmap.page.repository;
+
+import com.groot.mindmap.page.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PageRepository extends JpaRepository<Page, Long> {
+}

--- a/src/main/java/com/groot/mindmap/page/service/PageService.java
+++ b/src/main/java/com/groot/mindmap/page/service/PageService.java
@@ -1,0 +1,22 @@
+package com.groot.mindmap.page.service;
+
+import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.page.domain.Page;
+import com.groot.mindmap.page.repository.PageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PageService {
+
+    private final PageRepository repository;
+
+    public Long create() {
+        Page page = Page.builder().build();
+        Node defaultNode = Node.defaultNode();
+        defaultNode.setPage(page);
+        page.addNode(defaultNode);
+        return repository.save(page).getId();
+    }
+}

--- a/src/main/java/com/groot/mindmap/page/service/PageService.java
+++ b/src/main/java/com/groot/mindmap/page/service/PageService.java
@@ -5,6 +5,7 @@ import com.groot.mindmap.page.domain.Page;
 import com.groot.mindmap.page.repository.PageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -12,11 +13,17 @@ public class PageService {
 
     private final PageRepository repository;
 
+    @Transactional
     public Long create() {
         Page page = Page.builder().build();
         Node defaultNode = Node.defaultNode();
         defaultNode.setPage(page);
         page.addNode(defaultNode);
         return repository.save(page).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Page findById(Long id) {
+        return repository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 페이지가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/groot/mindmap/util/BaseTimeEntity.java
+++ b/src/main/java/com/groot/mindmap/util/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.groot.mindmap.util;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
# 추가 기능
- Page 생성 기능
- Node 생성 시 Page와 1대다 연관관계를 가지도록 설정
- Node 생성 시 부모 노드의 자식 리스트에 새로운 노드의 ID 추가

- Node 삭제 시 자식 노드가 모두 삭제되도록 변경
```java
  public void delete(final Long id) {
      Node parent = findNodeObject(id);
      if (parent.getParentId() == null) {
          throw new IllegalArgumentException("루트 노드는 삭제할 수 없습니다.");
      }
      for (Long childId : parent.getChildren()) {
          delete(childId);
      }
      repository.delete(parent);
  }
```
- Page의 모든 Node를 조회하는 API 추가
```java
{baseUrl}/api/nodes/list/{pageId}
```