### PR TITLE
feat(MS-43): 도메인 별 Entity 클래스 구현

### DIFF
--- a/src/main/java/com/groot/mindmap/page/domain/Page.java
+++ b/src/main/java/com/groot/mindmap/page/domain/Page.java
@@ -1,15 +1,22 @@
 package com.groot.mindmap.page.domain;
 
 import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.project.domain.Project;
 import com.groot.mindmap.util.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -19,7 +26,7 @@ import java.util.List;
 public class Page extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Builder.Default
@@ -32,10 +39,20 @@ public class Page extends BaseTimeEntity {
             orphanRemoval = true)
     private List<Node> nodes = new ArrayList<>();
 
-    public void addNode(Node node) {
-        this.nodes.add(node);
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Project project;
+
+    public void addNode(final Node node) {
+        nodes.add(node);
         if (node.getPage() != this) {
             node.setPage(this);
+        }
+    }
+
+    public void setProject(final Project project) {
+        this.project = project;
+        if (!project.getPages().contains(this)) {
+            project.getPages().add(this);
         }
     }
 }

--- a/src/main/java/com/groot/mindmap/project/domain/Participant.java
+++ b/src/main/java/com/groot/mindmap/project/domain/Participant.java
@@ -1,0 +1,48 @@
+package com.groot.mindmap.project.domain;
+
+import com.groot.mindmap.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    public void setUser(final User user) {
+        this.user = user;
+        if (!user.getParticipants().contains(this)) {
+            user.getParticipants().add(this);
+        }
+    }
+
+    public void setProject(final Project project) {
+        this.project = project;
+        if (!project.getParticipants().contains(this)) {
+            project.getParticipants().add(this);
+        }
+    }
+}

--- a/src/main/java/com/groot/mindmap/project/domain/Project.java
+++ b/src/main/java/com/groot/mindmap/project/domain/Project.java
@@ -1,0 +1,72 @@
+package com.groot.mindmap.project.domain;
+
+import com.groot.mindmap.page.domain.Page;
+import com.groot.mindmap.user.domain.User;
+import com.groot.mindmap.util.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Project extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Builder.Default
+    private String title = "제목 없음";
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "project",
+            cascade = {CascadeType.ALL},
+            orphanRemoval = true)
+    private List<Participant> participants = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "project",
+            cascade = {CascadeType.ALL},
+            orphanRemoval = true)
+    private List<Page> pages = new ArrayList<>();
+
+    public void addParticipant(final Participant participant) {
+        participants.add(participant);
+        if (participant.getProject() != this) {
+            participant.setProject(this);
+        }
+    }
+
+    public void addPage(final Page page) {
+        pages.add(page);
+        if (page.getProject() != this) {
+            page.setProject(this);
+        }
+    }
+
+    public void setOwner(final User user) {
+        this.owner = user;
+        if (!user.getProjects().contains(this)) {
+            user.getProjects().add(this);
+        }
+    }
+}

--- a/src/main/java/com/groot/mindmap/user/domain/User.java
+++ b/src/main/java/com/groot/mindmap/user/domain/User.java
@@ -1,10 +1,19 @@
 package com.groot.mindmap.user.domain;
 
+import com.groot.mindmap.project.domain.Participant;
+import com.groot.mindmap.project.domain.Project;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.*;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
@@ -17,8 +26,38 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
+
     private String email;
+
     private String profileImage;
+
     private String platform;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "owner",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private List<Project> projects = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private List<Participant> participants = new ArrayList<>();
+
+    public void addProject(final Project project) {
+        projects.add(project);
+        if (project.getOwner() != this) {
+            project.setOwner(this);
+        }
+    }
+
+    public void addParticipant(final Participant participant) {
+        participants.add(participant);
+        if (participant.getUser() != this) {
+            participant.setUser(this);
+        }
+    }
 }

--- a/src/test/java/com/groot/mindmap/page/domain/PageTest.java
+++ b/src/test/java/com/groot/mindmap/page/domain/PageTest.java
@@ -1,0 +1,53 @@
+package com.groot.mindmap.page.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.groot.mindmap.node.domain.Node;
+import com.groot.mindmap.project.domain.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PageTest {
+
+    private Page page;
+
+    @BeforeEach
+    void setUp() {
+        page = Page.builder().build();
+    }
+
+    @Test
+    @DisplayName("페이지를 생성한다.")
+    void create() {
+        assertThat(page.getTitle()).isEqualTo("제목 없음");
+    }
+
+    @Test
+    @DisplayName("페이지가 속해있는 프로젝트를 설정한다.")
+    void setProject() {
+        // given
+        final Project project = Project.builder()
+                .build();
+
+        // when
+        page.setProject(project);
+
+        // then
+        assertThat(page.getProject()).isEqualTo(project);
+        assertThat(project.getPages()).contains(page);
+    }
+
+    @Test
+    @DisplayName("페이지에 노드를 생성하고, 해당 노드를 페이지의 노드 리스트에 추가한다.")
+    void addNode() {
+        // given
+        final Node node = Node.defaultNode();
+
+        // when
+        page.addNode(node);
+
+        // then
+        assertThat(page.getNodes()).contains(node);
+    }
+}

--- a/src/test/java/com/groot/mindmap/project/domain/ParticipantTest.java
+++ b/src/test/java/com/groot/mindmap/project/domain/ParticipantTest.java
@@ -1,0 +1,59 @@
+package com.groot.mindmap.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.groot.mindmap.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ParticipantTest {
+
+    private Participant participant;
+
+    @BeforeEach
+    void setUp() {
+        participant = Participant.builder().build();
+    }
+
+    @Test
+    @DisplayName("Participant를 생성한다.")
+    void create() {
+        assertNotNull(participant);
+    }
+
+    @Test
+    @DisplayName("사용자를 설정한다.")
+    void setUser() {
+        // given
+        final User user = User.builder()
+                .name("테스트")
+                .email("test@gmail.com")
+                .profileImage("test.png")
+                .platform("google")
+                .build();
+
+        // when
+        participant.setUser(user);
+
+        // then
+        assertThat(participant.getUser()).isEqualTo(user);
+        assertThat(user.getParticipants()).contains(participant);
+    }
+
+    @Test
+    @DisplayName("프로젝트를 설정한다.")
+    void setProject() {
+        // given
+        final Project project = Project.builder()
+                .build();
+
+        // when
+        participant.setProject(project);
+
+        // then
+        assertThat(participant.getProject()).isEqualTo(project);
+        assertThat(project.getParticipants()).contains(participant);
+    }
+}

--- a/src/test/java/com/groot/mindmap/project/domain/ProjectTest.java
+++ b/src/test/java/com/groot/mindmap/project/domain/ProjectTest.java
@@ -1,0 +1,81 @@
+package com.groot.mindmap.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.groot.mindmap.page.domain.Page;
+import com.groot.mindmap.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProjectTest {
+
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        project = Project.builder().build();
+    }
+
+    @Test
+    @DisplayName("프로젝트를 생성한다.")
+    void create() {
+        assertThat(project.getTitle()).isEqualTo("제목 없음");
+    }
+
+    @Test
+    @DisplayName("프로젝트의 주인을 설정한다.")
+    void setOwner() {
+        // given
+        final User owner = User.builder()
+                .name("팀장")
+                .email("leader@gmail.com")
+                .profileImage("leader.png")
+                .platform("google")
+                .build();
+
+        // when
+        project.setOwner(owner);
+
+        // then
+        assertThat(project.getOwner()).isEqualTo(owner);
+        assertThat(owner.getProjects()).contains(project);
+    }
+
+    @Test
+    @DisplayName("사용자가 프로젝트에 참여하고, 프로젝트의 참여 리스트에 추가한다.")
+    void addParticipant() {
+        // given
+        final User user = User.builder()
+                .name("테스트")
+                .email("test@gmail.com")
+                .profileImage("test.png")
+                .platform("google")
+                .build();
+        final Participant participant = Participant.builder()
+                .user(user)
+                .project(project)
+                .build();
+
+        // when
+        project.addParticipant(participant);
+
+        // then
+        assertThat(project.getParticipants()).contains(participant);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 페이지를 생성하고, 해당 페이지를 프로젝트의 페이지 리스트에 추가한다.")
+    void addPage() {
+        // given
+        final Page page = Page.builder()
+                .project(project)
+                .build();
+
+        // when
+        project.addPage(page);
+
+        // then
+        assertThat(project.getPages()).contains(page);
+    }
+}

--- a/src/test/java/com/groot/mindmap/user/domain/UserTest.java
+++ b/src/test/java/com/groot/mindmap/user/domain/UserTest.java
@@ -1,0 +1,73 @@
+package com.groot.mindmap.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.groot.mindmap.project.domain.Participant;
+import com.groot.mindmap.project.domain.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .name("테스트")
+                .email("test@gmail.com")
+                .profileImage("test.png")
+                .platform("google")
+                .build();
+    }
+
+    @Test
+    @DisplayName("User를 생성한다.")
+    void create() {
+        assertThat(user.getName()).isEqualTo("테스트");
+        assertThat(user.getEmail()).isEqualTo("test@gmail.com");
+        assertThat(user.getProfileImage()).isEqualTo("test.png");
+        assertThat(user.getPlatform()).isEqualTo("google");
+    }
+
+    @Test
+    @DisplayName("사용자가 프로젝트를 생성하고, 해당 프로젝트를 사용자의 프로젝트 리스트에 추가한다.")
+    void addProject() {
+        // given
+        final Project project = Project.builder()
+                .owner(user)
+                .build();
+
+        // when
+        user.addProject(project);
+
+        // then
+        assertThat(user.getProjects()).contains(project);
+    }
+
+    @Test
+    @DisplayName("사용자가 프로젝트에 참여하고, 사용자의 참여 리스트에 추가한다.")
+    void addParticipant() {
+        // given
+        final User owner = User.builder()
+                .name("팀장")
+                .email("leader@gmail.com")
+                .profileImage("leader.png")
+                .platform("google")
+                .build();
+        final Project project = Project.builder()
+                .owner(owner)
+                .build();
+        final Participant participant = Participant.builder()
+                .user(user)
+                .project(project)
+                .build();
+
+        // when
+        user.addParticipant(participant);
+
+        // then
+        assertThat(user.getParticipants()).contains(participant);
+    }
+}


### PR DESCRIPTION
## 공통

- `Node` 클래스를 제외한 각각 domain 테스트 추가

## User

- `Project - User` : 다대일 양방향 관계 (User가 Project를 만들어서 팀장인 경우)
- 이 때, `User` 클래스의 필드명으로 `projects`가 적합한지?

## Participant

- `User - Project` 다대다 관계를 매핑하기 위해 생성된 중간 테이블
- 기존 DB 설계에서 변경된 사항
  - Java 컨벤션에 따라 `Participates` → `Participant`로 변경
  - `user_id`, `project_id`를 복합 키로 사용하는 방식 → id PK를 가지도록 `id` 필드 추가

## Project

- 기존 DB 설계에서 변경된 사항
  - `owner` → `owner_id`로 변경 (VARCHAR → BIGINT)

## Node

- parent와 children이 현재 id를 가지도록 되어있는데, `Node` 객체를 직접 참조하도록 추후 수정할 예정
- Node에 대한 도메인 테스트는 위 수정 사항 반영 후 추가할 예정